### PR TITLE
feat(object): add omit, merge, clone, has-path utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,61 @@ const publicInfo = pick(user, ['id', 'name']);
 // Result: { id: 1, name: 'John' }
 ```
 
+#### `object/omit`
+
+Creates a new object by omitting specified keys from the source object.
+
+```typescript
+import { omit } from './lib/utils/object-omit';
+
+const user = {
+  id: 1,
+  name: 'John',
+  email: 'john@example.com',
+  password: 'secret123',
+};
+const publicUser = omit(user, ['password', 'email']);
+// Result: { id: 1, name: 'John' }
+```
+
+#### `object/merge`
+
+Deep merges multiple objects into a single object.
+
+```typescript
+import { merge } from './lib/utils/object-merge';
+
+const obj1 = { a: 1, b: { x: 1, y: 2 } };
+const obj2 = { b: { z: 3 }, c: 4 };
+const merged = merge(obj1, obj2);
+// Result: { a: 1, b: { x: 1, y: 2, z: 3 }, c: 4 }
+```
+
+#### `object/clone`
+
+Creates a deep copy of an object.
+
+```typescript
+import { clone } from './lib/utils/object-clone';
+
+const original = { name: 'John', address: { city: 'NYC' } };
+const cloned = clone(original);
+cloned.address.city = 'LA';
+console.log(original.address.city); // 'NYC' (unchanged)
+```
+
+#### `object/has-path`
+
+Checks if a nested property path exists in an object.
+
+```typescript
+import { hasPath } from './lib/utils/object-has-path';
+
+const user = { profile: { settings: { theme: 'dark' } } };
+hasPath(user, 'profile.settings.theme'); // true
+hasPath(user, 'profile.settings.language'); // false
+```
+
 ### Promise Utilities
 
 #### `promise/delay`

--- a/registry/object/clone/index.test.ts
+++ b/registry/object/clone/index.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { clone } from './index';
+
+describe('clone', () => {
+  it('should clone primitive values', () => {
+    expect(clone(42)).toBe(42);
+    expect(clone('hello')).toBe('hello');
+    expect(clone(true)).toBe(true);
+    expect(clone(null)).toBe(null);
+    expect(clone(undefined)).toBe(undefined);
+  });
+
+  it('should clone simple objects', () => {
+    const original = { a: 1, b: 'hello', c: true };
+    const cloned = clone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
+  });
+
+  it('should clone nested objects', () => {
+    const original = {
+      name: 'John',
+      address: {
+        street: '123 Main St',
+        city: 'NYC',
+        coordinates: {
+          lat: 40.7128,
+          lng: -74.006,
+        },
+      },
+    };
+
+    const cloned = clone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
+    expect(cloned.address).not.toBe(original.address);
+    expect(cloned.address.coordinates).not.toBe(original.address.coordinates);
+
+    // Modify cloned object
+    cloned.address.city = 'LA';
+    expect(original.address.city).toBe('NYC');
+  });
+
+  it('should clone arrays', () => {
+    const original = [1, 'hello', true, { nested: 'value' }];
+    const cloned = clone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
+    expect(cloned[3]).not.toBe(original[3]);
+
+    // Modify cloned array
+    cloned[0] = 99;
+    (cloned[3] as { nested: string }).nested = 'changed';
+    expect(original[0]).toBe(1);
+    expect((original[3] as { nested: string }).nested).toBe('value');
+  });
+
+  it('should clone nested arrays', () => {
+    const original = [1, [2, [3, 4]], 5];
+    const cloned = clone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned[1]).not.toBe(original[1]);
+    expect((cloned[1] as number[])[1]).not.toBe((original[1] as number[][])[1]);
+  });
+
+  it('should clone Date objects', () => {
+    const date = new Date('2023-01-01');
+    const original = { created: date };
+    const cloned = clone(original);
+
+    expect(cloned.created).toEqual(date);
+    expect(cloned.created).not.toBe(date);
+    expect(cloned.created instanceof Date).toBe(true);
+  });
+
+  it('should clone RegExp objects', () => {
+    const regex = /test/gi;
+    const original = { pattern: regex };
+    const cloned = clone(original);
+
+    expect(cloned.pattern).toEqual(regex);
+    expect(cloned.pattern).not.toBe(regex);
+    expect(cloned.pattern instanceof RegExp).toBe(true);
+    expect(cloned.pattern.source).toBe('test');
+    expect(cloned.pattern.flags).toBe('gi');
+  });
+
+  it('should handle empty objects and arrays', () => {
+    const emptyObj = {};
+    const emptyArr: unknown[] = [];
+
+    expect(clone(emptyObj)).toEqual({});
+    expect(clone(emptyArr)).toEqual([]);
+    expect(clone(emptyObj)).not.toBe(emptyObj);
+    expect(clone(emptyArr)).not.toBe(emptyArr);
+  });
+
+  it('should handle circular references', () => {
+    const obj: { name: string; self?: unknown } = { name: 'circular' };
+    obj.self = obj;
+
+    const cloned = clone(obj) as {
+      name: string;
+      self: { name: string; self: unknown };
+    };
+
+    expect(cloned.name).toBe('circular');
+    expect(cloned.self).toBe(cloned); // Should reference itself
+    expect(cloned).not.toBe(obj); // But be a different object
+  });
+
+  it('should handle complex circular references', () => {
+    const a: { name: string; b?: unknown } = { name: 'a' };
+    const b: { name: string; a?: unknown } = { name: 'b' };
+    a.b = b;
+    b.a = a;
+
+    const clonedA = clone(a) as {
+      name: string;
+      b: { name: string; a: unknown };
+    };
+
+    expect(clonedA.name).toBe('a');
+    expect(clonedA.b.name).toBe('b');
+    expect(clonedA.b.a).toBe(clonedA); // Should maintain circular reference
+  });
+
+  it('should handle mixed data types', () => {
+    const original = {
+      str: 'hello',
+      num: 42,
+      bool: true,
+      nil: null,
+      undef: undefined,
+      date: new Date('2023-01-01'),
+      regex: /test/g,
+      arr: [1, 2, { nested: true }],
+      obj: {
+        deep: {
+          value: 'nested',
+        },
+      },
+    };
+
+    const cloned = clone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
+    expect(cloned.date).not.toBe(original.date);
+    expect(cloned.regex).not.toBe(original.regex);
+    expect(cloned.arr).not.toBe(original.arr);
+    expect(cloned.obj).not.toBe(original.obj);
+    expect(cloned.obj.deep).not.toBe(original.obj.deep);
+  });
+
+  it('should preserve object types', () => {
+    class CustomClass {
+      constructor(public value: string) {}
+    }
+
+    const instance = new CustomClass('test');
+    const obj = { instance };
+    const cloned = clone(obj);
+
+    // Note: Custom classes lose their prototype in deep cloning
+    // This is expected behavior for most deep clone implementations
+    expect(cloned.instance.value).toBe('test');
+  });
+
+  it('should not mutate original during cloning', () => {
+    const original = {
+      items: [{ id: 1 }, { id: 2 }],
+      meta: { count: 2 },
+    };
+    const originalStr = JSON.stringify(original);
+
+    const cloned = clone(original);
+    cloned.items.push({ id: 3 });
+    cloned.meta.count = 3;
+
+    expect(JSON.stringify(original)).toBe(originalStr);
+  });
+});

--- a/registry/object/clone/index.ts
+++ b/registry/object/clone/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Creates a deep copy of an object.
+ *
+ * Recursively clones all properties of an object, including nested objects and arrays.
+ * Handles circular references by maintaining a reference map. Primitive values,
+ * functions, and built-in objects like Date and RegExp are handled appropriately.
+ *
+ * @param obj The object to clone
+ * @returns A deep copy of the input object
+ *
+ * @example
+ * ```typescript
+ * const original = {
+ *   name: 'John',
+ *   age: 30,
+ *   address: {
+ *     street: '123 Main St',
+ *     city: 'NYC'
+ *   },
+ *   hobbies: ['reading', 'gaming']
+ * };
+ *
+ * const cloned = clone(original);
+ * cloned.address.city = 'LA';
+ * console.log(original.address.city); // 'NYC' (unchanged)
+ * console.log(cloned.address.city); // 'LA'
+ *
+ * // Works with arrays
+ * const arr = [1, { nested: true }, [2, 3]];
+ * const clonedArr = clone(arr);
+ * clonedArr[1].nested = false;
+ * console.log(arr[1].nested); // true (unchanged)
+ *
+ * // Handles dates and other built-ins
+ * const withDate = { created: new Date(), pattern: /test/g };
+ * const clonedDate = clone(withDate);
+ * console.log(clonedDate.created instanceof Date); // true
+ * ```
+ */
+export function clone<T>(obj: T): T {
+  return cloneWithMap(obj, new WeakMap());
+}
+
+/**
+ * Internal clone function that maintains a reference map to handle circular references
+ */
+function cloneWithMap<T>(obj: T, refs: WeakMap<object, unknown>): T {
+  // Handle primitive values
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  // Handle circular references
+  if (refs.has(obj as object)) {
+    return refs.get(obj as object) as T;
+  }
+
+  // Handle Date objects
+  if (obj instanceof Date) {
+    return new Date(obj.getTime()) as T;
+  }
+
+  // Handle RegExp objects
+  if (obj instanceof RegExp) {
+    return new RegExp(obj.source, obj.flags) as T;
+  }
+
+  // Handle Arrays
+  if (Array.isArray(obj)) {
+    const clonedArray: unknown[] = [];
+    refs.set(obj as object, clonedArray);
+
+    for (let i = 0; i < obj.length; i++) {
+      clonedArray[i] = cloneWithMap(obj[i], refs);
+    }
+
+    return clonedArray as T;
+  }
+
+  // Handle Objects
+  const clonedObj = {} as Record<string, unknown>;
+  refs.set(obj as object, clonedObj);
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      clonedObj[key] = cloneWithMap(
+        (obj as Record<string, unknown>)[key],
+        refs
+      );
+    }
+  }
+
+  return clonedObj as T;
+}

--- a/registry/object/has-path/index.test.ts
+++ b/registry/object/has-path/index.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { hasPath } from './index';
+
+describe('hasPath', () => {
+  const testObj = {
+    name: 'John',
+    age: 30,
+    address: {
+      street: '123 Main St',
+      city: 'NYC',
+      coordinates: {
+        lat: 40.7128,
+        lng: -74.006,
+        elevation: undefined,
+      },
+    },
+    hobbies: ['reading', 'gaming'],
+    settings: {
+      theme: 'dark',
+      notifications: {
+        email: true,
+        push: false,
+      },
+    },
+    empty: null,
+  };
+
+  it('should return true for existing top-level properties', () => {
+    expect(hasPath(testObj, 'name')).toBe(true);
+    expect(hasPath(testObj, 'age')).toBe(true);
+    expect(hasPath(testObj, 'address')).toBe(true);
+    expect(hasPath(testObj, 'hobbies')).toBe(true);
+  });
+
+  it('should return false for non-existing top-level properties', () => {
+    expect(hasPath(testObj, 'nonexistent')).toBe(false);
+    expect(hasPath(testObj, 'missing')).toBe(false);
+  });
+
+  it('should return true for existing nested properties using dot notation', () => {
+    expect(hasPath(testObj, 'address.street')).toBe(true);
+    expect(hasPath(testObj, 'address.city')).toBe(true);
+    expect(hasPath(testObj, 'address.coordinates.lat')).toBe(true);
+    expect(hasPath(testObj, 'address.coordinates.lng')).toBe(true);
+    expect(hasPath(testObj, 'settings.notifications.email')).toBe(true);
+  });
+
+  it('should return true for properties with undefined values', () => {
+    expect(hasPath(testObj, 'address.coordinates.elevation')).toBe(true);
+    expect(hasPath(testObj, 'empty')).toBe(true);
+  });
+
+  it('should return false for non-existing nested properties', () => {
+    expect(hasPath(testObj, 'address.zipcode')).toBe(false);
+    expect(hasPath(testObj, 'address.coordinates.altitude')).toBe(false);
+    expect(hasPath(testObj, 'settings.theme.color')).toBe(false);
+    expect(hasPath(testObj, 'nonexistent.property')).toBe(false);
+  });
+
+  it('should work with array notation using string path', () => {
+    expect(hasPath(testObj, ['name'])).toBe(true);
+    expect(hasPath(testObj, ['address', 'city'])).toBe(true);
+    expect(hasPath(testObj, ['address', 'coordinates', 'lat'])).toBe(true);
+    expect(hasPath(testObj, ['settings', 'notifications', 'push'])).toBe(true);
+  });
+
+  it('should return false with array notation for non-existing paths', () => {
+    expect(hasPath(testObj, ['nonexistent'])).toBe(false);
+    expect(hasPath(testObj, ['address', 'zipcode'])).toBe(false);
+    expect(hasPath(testObj, ['address', 'coordinates', 'altitude'])).toBe(
+      false
+    );
+  });
+
+  it('should work with array indices', () => {
+    expect(hasPath(testObj, 'hobbies.0')).toBe(true);
+    expect(hasPath(testObj, 'hobbies.1')).toBe(true);
+    expect(hasPath(testObj, 'hobbies.2')).toBe(false);
+  });
+
+  it('should work with array indices using array notation', () => {
+    expect(hasPath(testObj, ['hobbies', 0])).toBe(true);
+    expect(hasPath(testObj, ['hobbies', 1])).toBe(true);
+    expect(hasPath(testObj, ['hobbies', 2])).toBe(false);
+  });
+
+  it('should handle null and undefined objects', () => {
+    expect(hasPath(null, 'any.path')).toBe(false);
+    expect(hasPath(undefined, 'any.path')).toBe(false);
+    expect(hasPath(null, ['any', 'path'])).toBe(false);
+  });
+
+  it('should handle non-object inputs', () => {
+    expect(hasPath('string' as any, 'length')).toBe(false);
+    expect(hasPath(123 as any, 'toString')).toBe(false);
+    expect(hasPath(true as any, 'valueOf')).toBe(false);
+  });
+
+  it('should handle empty paths', () => {
+    expect(hasPath(testObj, '')).toBe(false);
+    expect(hasPath(testObj, [])).toBe(false);
+  });
+
+  it('should handle invalid path types', () => {
+    expect(hasPath(testObj, null as any)).toBe(false);
+    expect(hasPath(testObj, undefined as any)).toBe(false);
+  });
+
+  it('should return false when traversing through primitives', () => {
+    expect(hasPath(testObj, 'name.length')).toBe(false);
+    expect(hasPath(testObj, 'age.toString')).toBe(false);
+  });
+
+  it('should work with complex nested structures', () => {
+    const complex = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              value: 'deep',
+            },
+          },
+        },
+      },
+    };
+
+    expect(hasPath(complex, 'level1.level2.level3.level4.value')).toBe(true);
+    expect(hasPath(complex, 'level1.level2.level3.level4.missing')).toBe(false);
+    expect(hasPath(complex, 'level1.level2.missing.level4.value')).toBe(false);
+  });
+
+  it('should handle arrays of objects', () => {
+    const arrayObj = {
+      users: [
+        { id: 1, name: 'John' },
+        { id: 2, name: 'Jane' },
+      ],
+    };
+
+    expect(hasPath(arrayObj, 'users.0.id')).toBe(true);
+    expect(hasPath(arrayObj, 'users.0.name')).toBe(true);
+    expect(hasPath(arrayObj, 'users.1.id')).toBe(true);
+    expect(hasPath(arrayObj, 'users.2.id')).toBe(false);
+    expect(hasPath(arrayObj, 'users.0.age')).toBe(false);
+  });
+
+  it('should handle mixed array and object access', () => {
+    const mixed = {
+      data: {
+        items: [
+          {
+            details: {
+              info: 'nested',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(hasPath(mixed, 'data.items.0.details.info')).toBe(true);
+    expect(hasPath(mixed, ['data', 'items', 0, 'details', 'info'])).toBe(true);
+    expect(hasPath(mixed, 'data.items.1.details.info')).toBe(false);
+  });
+});

--- a/registry/object/has-path/index.ts
+++ b/registry/object/has-path/index.ts
@@ -1,0 +1,80 @@
+/**
+ * Checks if a nested property path exists in an object.
+ *
+ * Safely traverses nested object properties using a dot-notation path string
+ * or an array of keys. Returns true if the path exists (even if the final value
+ * is undefined), false if any part of the path is missing.
+ *
+ * @param obj The object to check
+ * @param path The property path as a string (dot notation) or array of keys
+ * @returns True if the path exists, false otherwise
+ *
+ * @example
+ * ```typescript
+ * const user = {
+ *   name: 'John',
+ *   address: {
+ *     street: '123 Main St',
+ *     city: 'NYC',
+ *     coordinates: {
+ *       lat: 40.7128,
+ *       lng: undefined
+ *     }
+ *   }
+ * };
+ *
+ * hasPath(user, 'name'); // true
+ * hasPath(user, 'address.city'); // true
+ * hasPath(user, 'address.coordinates.lat'); // true
+ * hasPath(user, 'address.coordinates.lng'); // true (exists but undefined)
+ * hasPath(user, 'address.zipcode'); // false
+ * hasPath(user, 'nonexistent'); // false
+ *
+ * // Using array notation
+ * hasPath(user, ['address', 'coordinates', 'lat']); // true
+ * hasPath(user, ['address', 'zipcode']); // false
+ *
+ * // Works with arrays
+ * const data = { items: [{ id: 1 }, { id: 2 }] };
+ * hasPath(data, 'items.0.id'); // true
+ * hasPath(data, 'items.2.id'); // false
+ * ```
+ */
+export function hasPath(
+  obj: Record<string, unknown> | null | undefined,
+  path: string | (string | number)[]
+): boolean {
+  // Handle edge cases
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+
+  // Convert string path to array
+  const keys = typeof path === 'string' ? path.split('.') : path;
+
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return false;
+  }
+
+  let current: unknown = obj;
+
+  for (const key of keys) {
+    // Check if current is an object or array
+    if (
+      !current ||
+      (typeof current !== 'object' && typeof current !== 'function')
+    ) {
+      return false;
+    }
+
+    // Check if key exists in current object/array
+    if (!(String(key) in current)) {
+      return false;
+    }
+
+    // Move to next level
+    current = (current as Record<string, unknown>)[String(key)];
+  }
+
+  return true;
+}

--- a/registry/object/merge/index.test.ts
+++ b/registry/object/merge/index.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { merge } from './index';
+
+describe('merge', () => {
+  it('should merge two simple objects', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { c: 3, d: 4 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it('should override properties from later objects', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { b: 3, c: 4 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('should deep merge nested objects', () => {
+    const obj1 = { a: 1, b: { x: 1, y: 2 } };
+    const obj2 = { b: { z: 3 }, c: 4 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: { x: 1, y: 2, z: 3 }, c: 4 });
+  });
+
+  it('should merge multiple objects', () => {
+    const obj1 = { a: 1 };
+    const obj2 = { b: 2 };
+    const obj3 = { c: 3 };
+    const result = merge(obj1, obj2, obj3);
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should handle empty objects', () => {
+    const obj1 = {};
+    const obj2 = { a: 1 };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should return empty object when no arguments', () => {
+    const result = merge();
+    expect(result).toEqual({});
+  });
+
+  it('should handle null and undefined inputs', () => {
+    const obj1 = { a: 1 };
+    const result = merge(obj1, null, undefined, { b: 2 });
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should replace arrays entirely', () => {
+    const obj1 = { items: [1, 2] };
+    const obj2 = { items: [3, 4] };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ items: [3, 4] });
+  });
+
+  it('should handle mixed data types', () => {
+    const obj1 = {
+      str: 'hello',
+      num: 42,
+      bool: true,
+      arr: [1, 2],
+      obj: { nested: 'value' },
+    };
+    const obj2 = {
+      str: 'world',
+      arr: [3, 4],
+      obj: { added: 'new' },
+      nil: null,
+    };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({
+      str: 'world',
+      num: 42,
+      bool: true,
+      arr: [3, 4],
+      obj: { nested: 'value', added: 'new' },
+      nil: null,
+    });
+  });
+
+  it('should handle deeply nested objects', () => {
+    const obj1 = {
+      level1: {
+        level2: {
+          level3: {
+            value: 'original',
+          },
+        },
+      },
+    };
+    const obj2 = {
+      level1: {
+        level2: {
+          level3: {
+            newValue: 'added',
+          },
+          newLevel3: 'new',
+        },
+      },
+    };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({
+      level1: {
+        level2: {
+          level3: {
+            value: 'original',
+            newValue: 'added',
+          },
+          newLevel3: 'new',
+        },
+      },
+    });
+  });
+
+  it('should not mutate original objects', () => {
+    const obj1 = { a: 1, b: { x: 1 } };
+    const obj2 = { b: { y: 2 }, c: 3 };
+    const obj1Copy = JSON.parse(JSON.stringify(obj1));
+    const obj2Copy = JSON.parse(JSON.stringify(obj2));
+
+    merge(obj1, obj2);
+
+    expect(obj1).toEqual(obj1Copy);
+    expect(obj2).toEqual(obj2Copy);
+  });
+
+  it('should handle overriding with null and undefined', () => {
+    const obj1 = { a: 1, b: 2, c: 3 };
+    const obj2 = { b: null, c: undefined };
+    const result = merge(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: null, c: undefined });
+  });
+
+  it('should ignore non-object inputs', () => {
+    const obj = { a: 1 };
+    const result = merge(
+      obj,
+      'string' as any,
+      123 as any,
+      true as any,
+      [1, 2] as any
+    );
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should handle complex merging scenario', () => {
+    const base = {
+      user: {
+        name: 'John',
+        settings: {
+          theme: 'light',
+          notifications: true,
+        },
+      },
+      meta: {
+        version: 1,
+      },
+    };
+
+    const update1 = {
+      user: {
+        age: 30,
+        settings: {
+          theme: 'dark',
+        },
+      },
+    };
+
+    const update2 = {
+      user: {
+        settings: {
+          language: 'en',
+        },
+      },
+      meta: {
+        updated: '2023-01-01',
+      },
+    };
+
+    const result = merge(base, update1, update2);
+    expect(result).toEqual({
+      user: {
+        name: 'John',
+        age: 30,
+        settings: {
+          theme: 'dark',
+          notifications: true,
+          language: 'en',
+        },
+      },
+      meta: {
+        version: 1,
+        updated: '2023-01-01',
+      },
+    });
+  });
+});

--- a/registry/object/merge/index.ts
+++ b/registry/object/merge/index.ts
@@ -1,0 +1,90 @@
+/**
+ * Deep merges multiple objects into a single object.
+ *
+ * Combines multiple objects by merging their properties recursively.
+ * Later objects in the arguments list will override properties of earlier objects.
+ * Arrays are replaced entirely rather than merged element by element.
+ *
+ * @param objects The objects to merge
+ * @returns A new object containing the merged properties
+ *
+ * @example
+ * ```typescript
+ * const obj1 = { a: 1, b: { x: 1, y: 2 } };
+ * const obj2 = { b: { z: 3 }, c: 4 };
+ * const merged = merge(obj1, obj2);
+ * console.log(merged); // { a: 1, b: { x: 1, y: 2, z: 3 }, c: 4 }
+ *
+ * // Multiple objects
+ * const base = { name: 'John', age: 30 };
+ * const update1 = { age: 31, city: 'NYC' };
+ * const update2 = { city: 'LA', country: 'USA' };
+ * const result = merge(base, update1, update2);
+ * console.log(result); // { name: 'John', age: 31, city: 'LA', country: 'USA' }
+ *
+ * // Arrays are replaced, not merged
+ * const arr1 = { items: [1, 2] };
+ * const arr2 = { items: [3, 4] };
+ * const arrMerged = merge(arr1, arr2);
+ * console.log(arrMerged); // { items: [3, 4] }
+ * ```
+ */
+export function merge(
+  ...objects: Array<Record<string, unknown> | null | undefined>
+): Record<string, unknown> {
+  if (objects.length === 0) {
+    return {};
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const obj of objects) {
+    if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+      mergeInto(result, obj);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Helper function to recursively merge one object into another
+ */
+function mergeInto(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): void {
+  for (const key in source) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      const sourceValue = source[key];
+      const targetValue = target[key];
+
+      if (
+        sourceValue &&
+        typeof sourceValue === 'object' &&
+        !Array.isArray(sourceValue) &&
+        targetValue &&
+        typeof targetValue === 'object' &&
+        !Array.isArray(targetValue)
+      ) {
+        // Both values are objects, create a new object and merge recursively
+        const newTarget = { ...targetValue };
+        mergeInto(
+          newTarget as Record<string, unknown>,
+          sourceValue as Record<string, unknown>
+        );
+        target[key] = newTarget;
+      } else {
+        // Replace the value (includes arrays, primitives, and null)
+        // For objects and arrays, we need to create a deep copy to avoid mutation
+        if (sourceValue && typeof sourceValue === 'object') {
+          target[key] = Array.isArray(sourceValue)
+            ? [...sourceValue]
+            : { ...sourceValue };
+        } else {
+          target[key] = sourceValue;
+        }
+      }
+    }
+  }
+}

--- a/registry/object/omit/index.test.ts
+++ b/registry/object/omit/index.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { omit } from './index';
+
+describe('omit', () => {
+  it('should omit specified keys from object', () => {
+    const user = {
+      id: 1,
+      name: 'John',
+      email: 'john@example.com',
+      password: 'secret123',
+    };
+    const result = omit(user, ['password', 'email']);
+    expect(result).toEqual({ id: 1, name: 'John' });
+  });
+
+  it('should handle omitting single key', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = omit(obj, ['b']);
+    expect(result).toEqual({ a: 1, c: 3 });
+  });
+
+  it('should handle omitting non-existent keys', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = omit(obj, ['d', 'e'] as any);
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should return copy when omitting empty keys array', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = omit(obj, []);
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+    expect(result).not.toBe(obj); // Should be a different object
+  });
+
+  it('should return empty object when omitting all keys', () => {
+    const obj = { a: 1, b: 2 };
+    const result = omit(obj, ['a', 'b']);
+    expect(result).toEqual({});
+  });
+
+  it('should handle empty object', () => {
+    const obj = {};
+    const result = omit(obj, ['a'] as any);
+    expect(result).toEqual({});
+  });
+
+  it('should handle null input', () => {
+    const result = omit(null, ['a'] as any);
+    expect(result).toEqual({});
+  });
+
+  it('should handle undefined input', () => {
+    const result = omit(undefined, ['a'] as any);
+    expect(result).toEqual({});
+  });
+
+  it('should handle array input', () => {
+    const arr = [1, 2, 3];
+    const result = omit(arr as any, ['0'] as any);
+    expect(result).toEqual({});
+  });
+
+  it('should handle mixed data types', () => {
+    const obj = {
+      str: 'hello',
+      num: 42,
+      bool: true,
+      arr: [1, 2, 3],
+      obj: { nested: 'value' },
+      nil: null,
+      undef: undefined,
+    };
+    const result = omit(obj, ['bool', 'nil', 'undef']);
+    expect(result).toEqual({
+      str: 'hello',
+      num: 42,
+      arr: [1, 2, 3],
+      obj: { nested: 'value' },
+    });
+  });
+
+  it('should preserve object properties', () => {
+    const obj = {
+      prop: 'value',
+      method: () => 'test',
+      number: 42,
+    };
+    const result = omit(obj, ['number']);
+    expect(result.method()).toBe('test');
+    expect(result.prop).toBe('value');
+  });
+
+  it('should not mutate original object', () => {
+    const original = { a: 1, b: 2, c: 3 };
+    const originalCopy = { ...original };
+    omit(original, ['b']);
+    expect(original).toEqual(originalCopy);
+  });
+
+  it('should handle string keys only', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = omit(obj, ['a', 'c']);
+    expect(result).toEqual({ b: 2 });
+  });
+
+  it('should work with complex objects', () => {
+    const complex = {
+      id: 1,
+      user: {
+        name: 'John',
+        details: {
+          age: 30,
+          city: 'NYC',
+        },
+      },
+      settings: {
+        theme: 'dark',
+        notifications: true,
+      },
+      metadata: {
+        created: '2023-01-01',
+        updated: '2023-06-01',
+      },
+    };
+
+    const result = omit(complex, ['metadata', 'settings']);
+    expect(result).toEqual({
+      id: 1,
+      user: {
+        name: 'John',
+        details: {
+          age: 30,
+          city: 'NYC',
+        },
+      },
+    });
+  });
+});

--- a/registry/object/omit/index.ts
+++ b/registry/object/omit/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Creates a new object by omitting specified keys from the source object.
+ *
+ * Returns a new object that contains all properties from the source object
+ * except for the specified keys. This is the opposite of the pick utility.
+ * The operation is shallow - nested objects are not deeply omitted.
+ *
+ * @param obj The source object to omit properties from
+ * @param keys Array of keys to omit from the object
+ * @returns A new object without the specified keys
+ *
+ * @example
+ * ```typescript
+ * const user = {
+ *   id: 1,
+ *   name: 'John',
+ *   email: 'john@example.com',
+ *   password: 'secret123',
+ *   age: 30
+ * };
+ *
+ * const publicUser = omit(user, ['password', 'email']);
+ * console.log(publicUser); // { id: 1, name: 'John', age: 30 }
+ *
+ * const minimal = omit(user, ['password', 'email', 'age']);
+ * console.log(minimal); // { id: 1, name: 'John' }
+ *
+ * // Omitting non-existent keys is safe
+ * const safe = omit(user, ['nonexistent', 'password']);
+ * console.log(safe); // { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+ * ```
+ */
+export function omit<T extends Record<string, unknown>, K extends keyof T>(
+  obj: T | null | undefined,
+  keys: K[]
+): Omit<T, K> {
+  // Handle edge cases
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return {} as Omit<T, K>;
+  }
+
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return { ...obj } as Omit<T, K>;
+  }
+
+  const keysToOmit = new Set(keys);
+  const result = {} as Omit<T, K>;
+
+  for (const key in obj) {
+    if (
+      Object.prototype.hasOwnProperty.call(obj, key) &&
+      !keysToOmit.has(key as unknown as K)
+    ) {
+      (result as Record<string, unknown>)[key] = obj[key];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
- Add object/omit utility to create objects without specified keys (complement to pick)
- Add object/merge utility for deep merging multiple objects recursively
- Add object/clone utility for creating deep copies with circular reference handling
- Add object/has-path utility to check if nested property paths exist
- Include comprehensive tests for all utilities with edge case coverage
- Update README.md documentation with usage examples for all new utilities
- All utilities follow project coding standards and handle TypeScript types properly