### PR TITLE
feat: add string case utilities (kebab-case, snake-case, camel-case, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,58 @@ capitalize('javaScript'); // 'JavaScript'
 capitalize(''); // ''
 ```
 
+#### `string/kebab-case`
+
+Converts a string to kebab-case.
+
+```typescript
+import { kebabCase } from './lib/utils/string-kebab-case';
+
+kebabCase('Hello World'); // 'hello-world'
+kebabCase('firstName'); // 'first-name'
+kebabCase('XMLHttpRequest'); // 'xml-http-request'
+kebabCase('snake_case_string'); // 'snake-case-string'
+```
+
+#### `string/snake-case`
+
+Converts a string to snake_case.
+
+```typescript
+import { snakeCase } from './lib/utils/string-snake-case';
+
+snakeCase('Hello World'); // 'hello_world'
+snakeCase('firstName'); // 'first_name'
+snakeCase('XMLHttpRequest'); // 'xml_http_request'
+snakeCase('kebab-case-string'); // 'kebab_case_string'
+```
+
+#### `string/camel-case`
+
+Converts a string to camelCase.
+
+```typescript
+import { camelCase } from './lib/utils/string-camel-case';
+
+camelCase('Hello World'); // 'helloWorld'
+camelCase('first_name'); // 'firstName'
+camelCase('kebab-case-string'); // 'kebabCaseString'
+camelCase('PascalCase'); // 'pascalCase'
+```
+
+#### `string/pascal-case`
+
+Converts a string to PascalCase.
+
+```typescript
+import { pascalCase } from './lib/utils/string-pascal-case';
+
+pascalCase('Hello World'); // 'HelloWorld'
+pascalCase('first_name'); // 'FirstName'
+pascalCase('kebab-case-string'); // 'KebabCaseString'
+pascalCase('camelCase'); // 'CamelCase'
+```
+
 ---
 
 ## CLI Commands

--- a/registry/string/camel-case/index.test.ts
+++ b/registry/string/camel-case/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { camelCase } from './index.js';
+
+describe('camelCase', () => {
+  it('should convert spaces to camelCase', () => {
+    expect(camelCase('Hello World')).toBe('helloWorld');
+    expect(camelCase('multiple word string')).toBe('multipleWordString');
+    expect(camelCase('  multiple   spaces  ')).toBe('multipleSpaces');
+  });
+
+  it('should convert snake_case to camelCase', () => {
+    expect(camelCase('first_name')).toBe('firstName');
+    expect(camelCase('background_color')).toBe('backgroundColor');
+    expect(camelCase('get_element_by_id')).toBe('getElementById');
+  });
+
+  it('should convert kebab-case to camelCase', () => {
+    expect(camelCase('kebab-case')).toBe('kebabCase');
+    expect(camelCase('kebab-case-string')).toBe('kebabCaseString');
+    expect(camelCase('mixed-kebab-and-spaces')).toBe('mixedKebabAndSpaces');
+  });
+
+  it('should convert PascalCase to camelCase', () => {
+    expect(camelCase('FirstName')).toBe('firstName');
+    expect(camelCase('XMLHttpRequest')).toBe('xmlHttpRequest');
+    expect(camelCase('HTMLElement')).toBe('htmlElement');
+  });
+
+  it('should handle mixed cases', () => {
+    expect(camelCase('camelCase_with_underscores')).toBe(
+      'camelCaseWithUnderscores'
+    );
+    expect(camelCase('PascalCase With Spaces')).toBe('pascalCaseWithSpaces');
+    expect(camelCase('mixed-Case AND spaces')).toBe('mixedCaseAndSpaces');
+  });
+
+  it('should handle already camelCase strings', () => {
+    expect(camelCase('alreadyCamelCase')).toBe('alreadyCamelCase');
+    expect(camelCase('multipleWordsHere')).toBe('multipleWordsHere');
+  });
+
+  it('should handle empty and whitespace strings', () => {
+    expect(camelCase('')).toBe('');
+    expect(camelCase('   ')).toBe('');
+    expect(camelCase('\t\n')).toBe('');
+  });
+
+  it('should handle single words', () => {
+    expect(camelCase('word')).toBe('word');
+    expect(camelCase('Word')).toBe('word');
+    expect(camelCase('WORD')).toBe('word');
+  });
+
+  it('should handle numbers and special characters', () => {
+    expect(camelCase('version 2 update')).toBe('version2Update');
+    expect(camelCase('HTML5 Parser')).toBe('html5Parser');
+    expect(camelCase('test-with-numbers-123')).toBe('testWithNumbers123');
+  });
+
+  it('should handle consecutive delimiters', () => {
+    expect(camelCase('multiple___underscores')).toBe('multipleUnderscores');
+    expect(camelCase('test---with---hyphens')).toBe('testWithHyphens');
+    expect(camelCase('mixed  _-  delimiters')).toBe('mixedDelimiters');
+  });
+
+  it('should handle leading and trailing delimiters', () => {
+    expect(camelCase('_leading_underscore')).toBe('leadingUnderscore');
+    expect(camelCase('trailing-hyphen-')).toBe('trailingHyphen');
+    expect(camelCase(' both sides ')).toBe('bothSides');
+  });
+});

--- a/registry/string/camel-case/index.ts
+++ b/registry/string/camel-case/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Converts a string to camelCase.
+ *
+ * Transforms a string by removing spaces, underscores, and hyphens, then capitalizing
+ * the first letter of each word except the first one. Commonly used for JavaScript
+ * variable names, object properties, and function names.
+ *
+ * @param str The string to convert
+ * @returns The camelCase version of the string
+ *
+ * @example
+ * ```typescript
+ * camelCase('Hello World'); // 'helloWorld'
+ * camelCase('first_name'); // 'firstName'
+ * camelCase('kebab-case-string'); // 'kebabCaseString'
+ * camelCase('PascalCase'); // 'pascalCase'
+ * camelCase('  multiple   spaces  '); // 'multipleSpaces'
+ * camelCase('alreadyCamelCase'); // 'alreadyCamelCase'
+ * camelCase(''); // ''
+ * ```
+ */
+export function camelCase(str: string): string {
+  if (!str) {
+    return '';
+  }
+
+  return (
+    str
+      .trim()
+      // Split on spaces, underscores, hyphens, and camelCase boundaries
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // XMLHttp -> XML Http
+      .replace(/([a-z])([A-Z])/g, '$1 $2') // Insert space before uppercase in camelCase
+      .replace(/([0-9])([A-Z])/g, '$1 $2') // version2Update -> version2 Update
+      .split(/[\s_-]+/)
+      .filter(word => word.length > 0)
+      .map((word, index) => {
+        const lowerWord = word.toLowerCase();
+        // First word stays lowercase, subsequent words get capitalized
+        return index === 0
+          ? lowerWord
+          : lowerWord.charAt(0).toUpperCase() + lowerWord.slice(1);
+      })
+      .join('')
+  );
+}

--- a/registry/string/kebab-case/index.test.ts
+++ b/registry/string/kebab-case/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { kebabCase } from './index.js';
+
+describe('kebabCase', () => {
+  it('should convert camelCase to kebab-case', () => {
+    expect(kebabCase('firstName')).toBe('first-name');
+    expect(kebabCase('backgroundColor')).toBe('background-color');
+    expect(kebabCase('getElementById')).toBe('get-element-by-id');
+  });
+
+  it('should convert PascalCase to kebab-case', () => {
+    expect(kebabCase('FirstName')).toBe('first-name');
+    expect(kebabCase('XMLHttpRequest')).toBe('xml-http-request');
+    expect(kebabCase('HTMLElement')).toBe('html-element');
+  });
+
+  it('should convert spaces to hyphens', () => {
+    expect(kebabCase('Hello World')).toBe('hello-world');
+    expect(kebabCase('multiple word string')).toBe('multiple-word-string');
+    expect(kebabCase('  multiple   spaces  ')).toBe('multiple-spaces');
+  });
+
+  it('should convert underscores to hyphens', () => {
+    expect(kebabCase('snake_case')).toBe('snake-case');
+    expect(kebabCase('snake_case_string')).toBe('snake-case-string');
+    expect(kebabCase('mixed_snake and spaces')).toBe('mixed-snake-and-spaces');
+  });
+
+  it('should handle mixed cases', () => {
+    expect(kebabCase('camelCase_with_underscores')).toBe(
+      'camel-case-with-underscores'
+    );
+    expect(kebabCase('PascalCase With Spaces')).toBe('pascal-case-with-spaces');
+    expect(kebabCase('mixed_Case AND spaces')).toBe('mixed-case-and-spaces');
+  });
+
+  it('should handle already kebab-case strings', () => {
+    expect(kebabCase('already-kebab-case')).toBe('already-kebab-case');
+    expect(kebabCase('multiple-words-here')).toBe('multiple-words-here');
+  });
+
+  it('should handle empty and whitespace strings', () => {
+    expect(kebabCase('')).toBe('');
+    expect(kebabCase('   ')).toBe('');
+    expect(kebabCase('\t\n')).toBe('');
+  });
+
+  it('should handle single words', () => {
+    expect(kebabCase('word')).toBe('word');
+    expect(kebabCase('Word')).toBe('word');
+    expect(kebabCase('WORD')).toBe('word');
+  });
+
+  it('should handle numbers and special characters', () => {
+    expect(kebabCase('version2Update')).toBe('version2-update');
+    expect(kebabCase('HTML5Parser')).toBe('html5-parser');
+    expect(kebabCase('test-with-numbers-123')).toBe('test-with-numbers-123');
+  });
+
+  it('should remove multiple consecutive hyphens', () => {
+    expect(kebabCase('multiple---hyphens')).toBe('multiple-hyphens');
+    expect(kebabCase('test__with__underscores')).toBe('test-with-underscores');
+  });
+
+  it('should remove leading and trailing hyphens', () => {
+    expect(kebabCase('-leading-hyphen')).toBe('leading-hyphen');
+    expect(kebabCase('trailing-hyphen-')).toBe('trailing-hyphen');
+    expect(kebabCase('-both-sides-')).toBe('both-sides');
+  });
+});

--- a/registry/string/kebab-case/index.ts
+++ b/registry/string/kebab-case/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Converts a string to kebab-case.
+ *
+ * Transforms a string by converting it to lowercase and replacing spaces, underscores,
+ * and camelCase boundaries with hyphens. Useful for creating URL slugs, CSS class names,
+ * and file names.
+ *
+ * @param str The string to convert
+ * @returns The kebab-case version of the string
+ *
+ * @example
+ * ```typescript
+ * kebabCase('Hello World'); // 'hello-world'
+ * kebabCase('firstName'); // 'first-name'
+ * kebabCase('XMLHttpRequest'); // 'xml-http-request'
+ * kebabCase('snake_case_string'); // 'snake-case-string'
+ * kebabCase('  multiple   spaces  '); // 'multiple-spaces'
+ * kebabCase('already-kebab-case'); // 'already-kebab-case'
+ * kebabCase(''); // ''
+ * ```
+ */
+export function kebabCase(str: string): string {
+  if (!str) {
+    return '';
+  }
+
+  return (
+    str
+      .trim()
+      // Handle consecutive uppercase letters followed by lowercase: XMLHttp -> XML-Http
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+      // Handle lowercase followed by uppercase: camelCase -> camel-Case
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      // Handle digit followed by letter: version2Update -> version2-Update
+      .replace(/([0-9])([A-Z])/g, '$1-$2')
+      // Replace underscores with hyphens
+      .replace(/_/g, '-')
+      // Replace one or more spaces with single hyphen
+      .replace(/\s+/g, '-')
+      // Convert to lowercase
+      .toLowerCase()
+      // Remove multiple consecutive hyphens
+      .replace(/-+/g, '-')
+      // Remove leading/trailing hyphens
+      .replace(/^-+|-+$/g, '')
+  );
+}

--- a/registry/string/pascal-case/index.test.ts
+++ b/registry/string/pascal-case/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { pascalCase } from './index.js';
+
+describe('pascalCase', () => {
+  it('should convert spaces to PascalCase', () => {
+    expect(pascalCase('Hello World')).toBe('HelloWorld');
+    expect(pascalCase('multiple word string')).toBe('MultipleWordString');
+    expect(pascalCase('  multiple   spaces  ')).toBe('MultipleSpaces');
+  });
+
+  it('should convert snake_case to PascalCase', () => {
+    expect(pascalCase('first_name')).toBe('FirstName');
+    expect(pascalCase('background_color')).toBe('BackgroundColor');
+    expect(pascalCase('get_element_by_id')).toBe('GetElementById');
+  });
+
+  it('should convert kebab-case to PascalCase', () => {
+    expect(pascalCase('kebab-case')).toBe('KebabCase');
+    expect(pascalCase('kebab-case-string')).toBe('KebabCaseString');
+    expect(pascalCase('mixed-kebab-and-spaces')).toBe('MixedKebabAndSpaces');
+  });
+
+  it('should convert camelCase to PascalCase', () => {
+    expect(pascalCase('firstName')).toBe('FirstName');
+    expect(pascalCase('xmlHttpRequest')).toBe('XmlHttpRequest');
+    expect(pascalCase('htmlElement')).toBe('HtmlElement');
+  });
+
+  it('should handle mixed cases', () => {
+    expect(pascalCase('camelCase_with_underscores')).toBe(
+      'CamelCaseWithUnderscores'
+    );
+    expect(pascalCase('PascalCase With Spaces')).toBe('PascalCaseWithSpaces');
+    expect(pascalCase('mixed-Case AND spaces')).toBe('MixedCaseAndSpaces');
+  });
+
+  it('should handle already PascalCase strings', () => {
+    expect(pascalCase('AlreadyPascalCase')).toBe('AlreadyPascalCase');
+    expect(pascalCase('MultipleWordsHere')).toBe('MultipleWordsHere');
+  });
+
+  it('should handle empty and whitespace strings', () => {
+    expect(pascalCase('')).toBe('');
+    expect(pascalCase('   ')).toBe('');
+    expect(pascalCase('\t\n')).toBe('');
+  });
+
+  it('should handle single words', () => {
+    expect(pascalCase('word')).toBe('Word');
+    expect(pascalCase('Word')).toBe('Word');
+    expect(pascalCase('WORD')).toBe('Word');
+  });
+
+  it('should handle numbers and special characters', () => {
+    expect(pascalCase('version 2 update')).toBe('Version2Update');
+    expect(pascalCase('HTML5 Parser')).toBe('Html5Parser');
+    expect(pascalCase('test-with-numbers-123')).toBe('TestWithNumbers123');
+  });
+
+  it('should handle consecutive delimiters', () => {
+    expect(pascalCase('multiple___underscores')).toBe('MultipleUnderscores');
+    expect(pascalCase('test---with---hyphens')).toBe('TestWithHyphens');
+    expect(pascalCase('mixed  _-  delimiters')).toBe('MixedDelimiters');
+  });
+
+  it('should handle leading and trailing delimiters', () => {
+    expect(pascalCase('_leading_underscore')).toBe('LeadingUnderscore');
+    expect(pascalCase('trailing-hyphen-')).toBe('TrailingHyphen');
+    expect(pascalCase(' both sides ')).toBe('BothSides');
+  });
+});

--- a/registry/string/pascal-case/index.ts
+++ b/registry/string/pascal-case/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Converts a string to PascalCase.
+ *
+ * Transforms a string by removing spaces, underscores, and hyphens, then capitalizing
+ * the first letter of each word including the first one. Commonly used for class names,
+ * interface names, type names, and component names.
+ *
+ * @param str The string to convert
+ * @returns The PascalCase version of the string
+ *
+ * @example
+ * ```typescript
+ * pascalCase('Hello World'); // 'HelloWorld'
+ * pascalCase('first_name'); // 'FirstName'
+ * pascalCase('kebab-case-string'); // 'KebabCaseString'
+ * pascalCase('camelCase'); // 'CamelCase'
+ * pascalCase('  multiple   spaces  '); // 'MultipleSpaces'
+ * pascalCase('AlreadyPascalCase'); // 'AlreadyPascalCase'
+ * pascalCase(''); // ''
+ * ```
+ */
+export function pascalCase(str: string): string {
+  if (!str) {
+    return '';
+  }
+
+  return (
+    str
+      .trim()
+      // Split on spaces, underscores, hyphens, and camelCase boundaries
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // XMLHttp -> XML Http
+      .replace(/([a-z])([A-Z])/g, '$1 $2') // Insert space before uppercase in camelCase
+      .replace(/([0-9])([A-Z])/g, '$1 $2') // version2Update -> version2 Update
+      .split(/[\s_-]+/)
+      .filter(word => word.length > 0)
+      .map(word => {
+        const lowerWord = word.toLowerCase();
+        // Capitalize first letter of every word
+        return lowerWord.charAt(0).toUpperCase() + lowerWord.slice(1);
+      })
+      .join('')
+  );
+}

--- a/registry/string/snake-case/index.test.ts
+++ b/registry/string/snake-case/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { snakeCase } from './index.js';
+
+describe('snakeCase', () => {
+  it('should convert camelCase to snake_case', () => {
+    expect(snakeCase('firstName')).toBe('first_name');
+    expect(snakeCase('backgroundColor')).toBe('background_color');
+    expect(snakeCase('getElementById')).toBe('get_element_by_id');
+  });
+
+  it('should convert PascalCase to snake_case', () => {
+    expect(snakeCase('FirstName')).toBe('first_name');
+    expect(snakeCase('XMLHttpRequest')).toBe('xml_http_request');
+    expect(snakeCase('HTMLElement')).toBe('html_element');
+  });
+
+  it('should convert spaces to underscores', () => {
+    expect(snakeCase('Hello World')).toBe('hello_world');
+    expect(snakeCase('multiple word string')).toBe('multiple_word_string');
+    expect(snakeCase('  multiple   spaces  ')).toBe('multiple_spaces');
+  });
+
+  it('should convert hyphens to underscores', () => {
+    expect(snakeCase('kebab-case')).toBe('kebab_case');
+    expect(snakeCase('kebab-case-string')).toBe('kebab_case_string');
+    expect(snakeCase('mixed-kebab and spaces')).toBe('mixed_kebab_and_spaces');
+  });
+
+  it('should handle mixed cases', () => {
+    expect(snakeCase('camelCase-with-hyphens')).toBe('camel_case_with_hyphens');
+    expect(snakeCase('PascalCase With Spaces')).toBe('pascal_case_with_spaces');
+    expect(snakeCase('mixed-Case AND spaces')).toBe('mixed_case_and_spaces');
+  });
+
+  it('should handle already snake_case strings', () => {
+    expect(snakeCase('already_snake_case')).toBe('already_snake_case');
+    expect(snakeCase('multiple_words_here')).toBe('multiple_words_here');
+  });
+
+  it('should handle empty and whitespace strings', () => {
+    expect(snakeCase('')).toBe('');
+    expect(snakeCase('   ')).toBe('');
+    expect(snakeCase('\t\n')).toBe('');
+  });
+
+  it('should handle single words', () => {
+    expect(snakeCase('word')).toBe('word');
+    expect(snakeCase('Word')).toBe('word');
+    expect(snakeCase('WORD')).toBe('word');
+  });
+
+  it('should handle numbers and special characters', () => {
+    expect(snakeCase('version2Update')).toBe('version2_update');
+    expect(snakeCase('HTML5Parser')).toBe('html5_parser');
+    expect(snakeCase('test_with_numbers_123')).toBe('test_with_numbers_123');
+  });
+
+  it('should remove multiple consecutive underscores', () => {
+    expect(snakeCase('multiple___underscores')).toBe('multiple_underscores');
+    expect(snakeCase('test--with--hyphens')).toBe('test_with_hyphens');
+  });
+
+  it('should remove leading and trailing underscores', () => {
+    expect(snakeCase('_leading_underscore')).toBe('leading_underscore');
+    expect(snakeCase('trailing_underscore_')).toBe('trailing_underscore');
+    expect(snakeCase('_both_sides_')).toBe('both_sides');
+  });
+});

--- a/registry/string/snake-case/index.ts
+++ b/registry/string/snake-case/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Converts a string to snake_case.
+ *
+ * Transforms a string by converting it to lowercase and replacing spaces, hyphens,
+ * and camelCase boundaries with underscores. Commonly used for database column names,
+ * Python variables, and configuration keys.
+ *
+ * @param str The string to convert
+ * @returns The snake_case version of the string
+ *
+ * @example
+ * ```typescript
+ * snakeCase('Hello World'); // 'hello_world'
+ * snakeCase('firstName'); // 'first_name'
+ * snakeCase('XMLHttpRequest'); // 'xml_http_request'
+ * snakeCase('kebab-case-string'); // 'kebab_case_string'
+ * snakeCase('  multiple   spaces  '); // 'multiple_spaces'
+ * snakeCase('already_snake_case'); // 'already_snake_case'
+ * snakeCase(''); // ''
+ * ```
+ */
+export function snakeCase(str: string): string {
+  if (!str) {
+    return '';
+  }
+
+  return (
+    str
+      .trim()
+      // Handle consecutive uppercase letters followed by lowercase: XMLHttp -> XML_Http
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+      // Handle lowercase followed by uppercase: camelCase -> camel_Case
+      .replace(/([a-z])([A-Z])/g, '$1_$2')
+      // Handle digit followed by letter: version2Update -> version2_Update
+      .replace(/([0-9])([A-Z])/g, '$1_$2')
+      // Replace hyphens with underscores
+      .replace(/-/g, '_')
+      // Replace one or more spaces with single underscore
+      .replace(/\s+/g, '_')
+      // Convert to lowercase
+      .toLowerCase()
+      // Remove multiple consecutive underscores
+      .replace(/_+/g, '_')
+      // Remove leading/trailing underscores
+      .replace(/^_+|_+$/g, '')
+  );
+}


### PR DESCRIPTION
…pascal-case)

- Add kebab-case utility for converting strings to kebab-case format
- Add snake-case utility for converting strings to snake_case format
- Add camel-case utility for converting strings to camelCase format
- Add pascal-case utility for converting strings to PascalCase format
- Handle complex cases like XMLHttpRequest, version2Update correctly
- Comprehensive test coverage with 44 test cases across all utilities
- Updated README.md with documentation and examples
- All utilities properly handle consecutive uppercase letters and digit boundaries