### PR TITLE
feat: add number utilities (clamp, random, round, format-number)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,60 @@ for (const item of items) {
 }
 ```
 
+### Number Utilities
+
+#### `number/clamp`
+
+Clamps a number between a minimum and maximum value.
+
+```typescript
+import { clamp } from './lib/utils/number-clamp';
+
+clamp(10, 0, 5); // 5
+clamp(-5, 0, 10); // 0
+clamp(7, 0, 10); // 7
+clamp(3.7, 1.5, 8.2); // 3.7
+```
+
+#### `number/random`
+
+Generates a random number between min and max.
+
+```typescript
+import { random } from './lib/utils/number-random';
+
+random(0, 1); // e.g., 0.7234 (float)
+random(5, 10); // e.g., 7.832 (float)
+random(1, 7, true); // e.g., 4 (integer)
+random(0, 101, true); // e.g., 42 (integer)
+```
+
+#### `number/round`
+
+Rounds a number to a specified number of decimal places.
+
+```typescript
+import { round } from './lib/utils/number-round';
+
+round(3.14159); // 3
+round(3.14159, 2); // 3.14
+round(3.14159, 4); // 3.1416
+round(123.456, -1); // 120 (round to nearest 10)
+```
+
+#### `number/format-number`
+
+Formats a number with thousands separators and decimal places.
+
+```typescript
+import { formatNumber } from './lib/utils/number-format-number';
+
+formatNumber(1234.567); // '1,234.567'
+formatNumber(1234.567, { decimals: 2 }); // '1,234.57'
+formatNumber(1234567, { thousandsSeparator: ' ' }); // '1 234 567'
+formatNumber(1234.5, { decimalSeparator: ',' }); // '1,234,5'
+```
+
 ### String Utilities
 
 #### `string/capitalize`

--- a/registry/number/clamp/index.test.ts
+++ b/registry/number/clamp/index.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { clamp } from './index.js';
+
+describe('clamp', () => {
+  it('should clamp values above the maximum', () => {
+    expect(clamp(10, 0, 5)).toBe(5);
+    expect(clamp(25, 10, 20)).toBe(20);
+    expect(clamp(100, 0, 50)).toBe(50);
+  });
+
+  it('should clamp values below the minimum', () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+    expect(clamp(5, 10, 20)).toBe(10);
+    expect(clamp(-100, -50, 0)).toBe(-50);
+  });
+
+  it('should return the value if within bounds', () => {
+    expect(clamp(7, 0, 10)).toBe(7);
+    expect(clamp(15, 10, 20)).toBe(15);
+    expect(clamp(0, -5, 5)).toBe(0);
+    expect(clamp(-2, -10, 10)).toBe(-2);
+  });
+
+  it('should handle decimal numbers', () => {
+    expect(clamp(3.7, 1.5, 8.2)).toBe(3.7);
+    expect(clamp(0.5, 1.0, 2.0)).toBe(1.0);
+    expect(clamp(2.5, 1.0, 2.0)).toBe(2.0);
+    expect(clamp(1.75, 1.0, 2.0)).toBe(1.75);
+  });
+
+  it('should handle edge cases where value equals bounds', () => {
+    expect(clamp(5, 5, 10)).toBe(5);
+    expect(clamp(10, 5, 10)).toBe(10);
+    expect(clamp(0, 0, 0)).toBe(0);
+  });
+
+  it('should handle negative numbers', () => {
+    expect(clamp(-15, -20, -10)).toBe(-15);
+    expect(clamp(-25, -20, -10)).toBe(-20);
+    expect(clamp(-5, -20, -10)).toBe(-10);
+  });
+
+  it('should handle very large numbers', () => {
+    expect(clamp(Number.MAX_SAFE_INTEGER, 0, 1000)).toBe(1000);
+    expect(clamp(Number.MIN_SAFE_INTEGER, -1000, 0)).toBe(-1000);
+  });
+
+  it('should handle special number values', () => {
+    expect(clamp(Infinity, 0, 100)).toBe(100);
+    expect(clamp(-Infinity, 0, 100)).toBe(0);
+    expect(clamp(NaN, 0, 100)).toBe(NaN);
+  });
+
+  it('should throw error when min > max', () => {
+    expect(() => clamp(5, 10, 5)).toThrow(
+      'Minimum value cannot be greater than maximum value'
+    );
+    expect(() => clamp(0, 1, 0)).toThrow(
+      'Minimum value cannot be greater than maximum value'
+    );
+  });
+});

--- a/registry/number/clamp/index.ts
+++ b/registry/number/clamp/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Clamps a number between a minimum and maximum value.
+ *
+ * Ensures a number stays within specified bounds. If the number is less than
+ * the minimum, returns the minimum. If greater than the maximum, returns the
+ * maximum. Otherwise returns the original number.
+ *
+ * @param value The number to clamp
+ * @param min The minimum allowed value
+ * @param max The maximum allowed value
+ * @returns The clamped number
+ *
+ * @example
+ * ```typescript
+ * clamp(10, 0, 5); // 5
+ * clamp(-5, 0, 10); // 0
+ * clamp(7, 0, 10); // 7
+ * clamp(3.7, 1.5, 8.2); // 3.7
+ * clamp(15, 10, 20); // 15
+ * clamp(25, 10, 20); // 20
+ * clamp(5, 10, 20); // 10
+ * ```
+ */
+export function clamp(value: number, min: number, max: number): number {
+  if (min > max) {
+    throw new Error('Minimum value cannot be greater than maximum value');
+  }
+
+  return Math.max(min, Math.min(max, value));
+}

--- a/registry/number/format-number/index.test.ts
+++ b/registry/number/format-number/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { formatNumber } from './index.js';
+
+describe('formatNumber', () => {
+  it('should format numbers with default thousands separator', () => {
+    expect(formatNumber(1234)).toBe('1,234');
+    expect(formatNumber(1234567)).toBe('1,234,567');
+    expect(formatNumber(1234567890)).toBe('1,234,567,890');
+  });
+
+  it('should handle decimal numbers', () => {
+    expect(formatNumber(1234.567)).toBe('1,234.567');
+    expect(formatNumber(1000.5)).toBe('1,000.5');
+    expect(formatNumber(123.456789)).toBe('123.456789');
+  });
+
+  it('should format with specified decimal places', () => {
+    expect(formatNumber(1234.567, { decimals: 2 })).toBe('1,234.57');
+    expect(formatNumber(1234.567, { decimals: 0 })).toBe('1,235');
+    expect(formatNumber(1234.567, { decimals: 4 })).toBe('1,234.5670');
+    expect(formatNumber(1234, { decimals: 2 })).toBe('1,234.00');
+  });
+
+  it('should handle custom thousands separator', () => {
+    expect(formatNumber(1234567, { thousandsSeparator: ' ' })).toBe(
+      '1 234 567'
+    );
+    expect(formatNumber(1234567, { thousandsSeparator: '.' })).toBe(
+      '1.234.567'
+    );
+    expect(formatNumber(1234567, { thousandsSeparator: '_' })).toBe(
+      '1_234_567'
+    );
+    expect(formatNumber(1234567, { thousandsSeparator: '' })).toBe('1234567');
+  });
+
+  it('should handle custom decimal separator', () => {
+    expect(formatNumber(1234.567, { decimalSeparator: ',' })).toBe('1,234,567');
+    expect(formatNumber(1234.567, { decimalSeparator: '|' })).toBe('1,234|567');
+  });
+
+  it('should handle European-style formatting', () => {
+    expect(
+      formatNumber(1234.567, {
+        thousandsSeparator: '.',
+        decimalSeparator: ',',
+      })
+    ).toBe('1.234,567');
+
+    expect(
+      formatNumber(1234567.89, {
+        thousandsSeparator: ' ',
+        decimalSeparator: ',',
+        decimals: 2,
+      })
+    ).toBe('1 234 567,89');
+  });
+
+  it('should handle negative numbers', () => {
+    expect(formatNumber(-1234.567)).toBe('-1,234.567');
+    expect(formatNumber(-1234567, { decimals: 2 })).toBe('-1,234,567.00');
+    expect(
+      formatNumber(-1234.567, {
+        thousandsSeparator: ' ',
+        decimalSeparator: ',',
+      })
+    ).toBe('-1 234,567');
+  });
+
+  it('should handle zero and small numbers', () => {
+    expect(formatNumber(0)).toBe('0');
+    expect(formatNumber(0, { decimals: 2 })).toBe('0.00');
+    expect(formatNumber(0.123, { decimals: 4 })).toBe('0.1230');
+    expect(formatNumber(123, { decimals: 0 })).toBe('123');
+  });
+
+  it('should handle numbers less than 1000', () => {
+    expect(formatNumber(123)).toBe('123');
+    expect(formatNumber(123.45)).toBe('123.45');
+    expect(formatNumber(999, { decimals: 2 })).toBe('999.00');
+  });
+
+  it('should handle special number values', () => {
+    expect(formatNumber(Infinity)).toBe('Infinity');
+    expect(formatNumber(-Infinity)).toBe('-Infinity');
+    expect(formatNumber(NaN)).toBe('NaN');
+  });
+
+  it('should handle very large numbers', () => {
+    expect(formatNumber(1e15)).toBe('1,000,000,000,000,000');
+    expect(formatNumber(9876543210123, { decimals: 2 })).toBe(
+      '9,876,543,210,123.00'
+    );
+  });
+
+  it('should handle rounding correctly', () => {
+    expect(formatNumber(1234.999, { decimals: 2 })).toBe('1,235.00');
+    expect(formatNumber(1234.994, { decimals: 2 })).toBe('1,234.99');
+    expect(formatNumber(1234.996, { decimals: 2 })).toBe('1,235.00');
+  });
+
+  it('should handle edge case with zero decimals', () => {
+    expect(formatNumber(1234.9, { decimals: 0 })).toBe('1,235');
+    expect(formatNumber(1234.1, { decimals: 0 })).toBe('1,234');
+    expect(formatNumber(1234.5, { decimals: 0 })).toBe('1,235');
+  });
+
+  it('should handle complex combinations', () => {
+    expect(
+      formatNumber(1234567.89123, {
+        decimals: 3,
+        thousandsSeparator: '_',
+        decimalSeparator: ':',
+      })
+    ).toBe('1_234_567:891');
+
+    expect(
+      formatNumber(-987654321.123456, {
+        decimals: 1,
+        thousandsSeparator: ' ',
+        decimalSeparator: ',',
+      })
+    ).toBe('-987 654 321,1');
+  });
+});

--- a/registry/number/format-number/index.ts
+++ b/registry/number/format-number/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Formats a number with thousands separators and decimal places.
+ *
+ * Provides locale-aware number formatting with options for thousands separators,
+ * decimal places, and custom separators. Useful for displaying numbers in
+ * user interfaces, reports, and financial applications.
+ *
+ * @param value The number to format
+ * @param options Formatting options
+ * @returns The formatted number string
+ *
+ * @example
+ * ```typescript
+ * formatNumber(1234.567); // '1,234.567'
+ * formatNumber(1234.567, { decimals: 2 }); // '1,234.57'
+ * formatNumber(1234567.89, { decimals: 0 }); // '1,234,568'
+ * formatNumber(1234.5, { thousandsSeparator: ' ' }); // '1 234.5'
+ * formatNumber(1234.5, { decimalSeparator: ',' }); // '1,234,5'
+ * formatNumber(1234.567, { thousandsSeparator: '.', decimalSeparator: ',' }); // '1.234,567'
+ * formatNumber(-1234.567, { decimals: 2 }); // '-1,234.57'
+ * formatNumber(0.123, { decimals: 4 }); // '0.1230'
+ * ```
+ */
+
+export interface FormatNumberOptions {
+  /** Number of decimal places to show */
+  decimals?: number;
+  /** Character used to separate thousands (default: ',') */
+  thousandsSeparator?: string;
+  /** Character used as decimal point (default: '.') */
+  decimalSeparator?: string;
+}
+
+export function formatNumber(
+  value: number,
+  options: FormatNumberOptions = {}
+): string {
+  if (!Number.isFinite(value)) {
+    return String(value);
+  }
+
+  const {
+    decimals,
+    thousandsSeparator = ',',
+    decimalSeparator = '.',
+  } = options;
+
+  // Handle the sign
+  const isNegative = value < 0;
+  const absoluteValue = Math.abs(value);
+
+  // Round to specified decimal places if provided
+  let roundedValue = absoluteValue;
+  if (decimals !== undefined) {
+    const factor = Math.pow(10, decimals);
+    roundedValue = Math.round(absoluteValue * factor) / factor;
+  }
+
+  // Split into integer and decimal parts
+  const valueString = roundedValue.toString();
+  const [integerPart, decimalPart = ''] = valueString.split('.');
+
+  // Add thousands separators to integer part
+  const formattedInteger = integerPart.replace(
+    /\B(?=(\d{3})+(?!\d))/g,
+    thousandsSeparator
+  );
+
+  // Handle decimal part
+  let formattedDecimal = decimalPart;
+  if (decimals !== undefined) {
+    // Pad or truncate to exact decimal places
+    formattedDecimal = decimalPart.padEnd(decimals, '0').slice(0, decimals);
+  }
+
+  // Combine parts
+  let result = formattedInteger;
+  if (formattedDecimal.length > 0) {
+    result += decimalSeparator + formattedDecimal;
+  }
+
+  // Add negative sign if needed
+  return isNegative ? `-${result}` : result;
+}

--- a/registry/number/random/index.test.ts
+++ b/registry/number/random/index.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { random } from './index.js';
+
+describe('random', () => {
+  it('should return a number within the specified range for floats', () => {
+    for (let i = 0; i < 100; i++) {
+      const result = random(0, 10);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(10);
+    }
+  });
+
+  it('should return an integer within the specified range when integer=true', () => {
+    for (let i = 0; i < 100; i++) {
+      const result = random(1, 7, true);
+      expect(result).toBeGreaterThanOrEqual(1);
+      expect(result).toBeLessThan(7);
+      expect(Number.isInteger(result)).toBe(true);
+    }
+  });
+
+  it('should handle negative ranges', () => {
+    for (let i = 0; i < 50; i++) {
+      const result = random(-10, -5);
+      expect(result).toBeGreaterThanOrEqual(-10);
+      expect(result).toBeLessThan(-5);
+    }
+  });
+
+  it('should handle ranges crossing zero', () => {
+    for (let i = 0; i < 50; i++) {
+      const result = random(-5, 5);
+      expect(result).toBeGreaterThanOrEqual(-5);
+      expect(result).toBeLessThan(5);
+    }
+  });
+
+  it('should return min when min equals max', () => {
+    expect(random(5, 5)).toBe(5);
+    expect(random(0, 0)).toBe(0);
+    expect(random(-3, -3)).toBe(-3);
+  });
+
+  it('should handle decimal ranges', () => {
+    for (let i = 0; i < 50; i++) {
+      const result = random(1.5, 2.5);
+      expect(result).toBeGreaterThanOrEqual(1.5);
+      expect(result).toBeLessThan(2.5);
+    }
+  });
+
+  it('should throw error when min > max', () => {
+    expect(() => random(10, 5)).toThrow(
+      'Minimum value cannot be greater than maximum value'
+    );
+    expect(() => random(1, 0)).toThrow(
+      'Minimum value cannot be greater than maximum value'
+    );
+  });
+
+  it('should use Math.random internally', () => {
+    const mockRandom = vi.spyOn(Math, 'random');
+    mockRandom.mockReturnValue(0.5);
+
+    const result = random(0, 10);
+    expect(result).toBe(5);
+    expect(mockRandom).toHaveBeenCalled();
+
+    mockRandom.mockRestore();
+  });
+
+  it('should generate different values on multiple calls', () => {
+    const values = new Set();
+    for (let i = 0; i < 50; i++) {
+      values.add(random(0, 1000));
+    }
+    // Should have generated many different values (allowing for some rare duplicates)
+    expect(values.size).toBeGreaterThan(40);
+  });
+
+  it('should handle integer generation correctly', () => {
+    const mockRandom = vi.spyOn(Math, 'random');
+
+    // Test edge cases for integer generation
+    mockRandom.mockReturnValue(0); // Should give min
+    expect(random(1, 6, true)).toBe(1);
+
+    mockRandom.mockReturnValue(0.99999); // Should give max-1
+    expect(random(1, 6, true)).toBe(5);
+
+    mockRandom.mockRestore();
+  });
+});

--- a/registry/number/random/index.ts
+++ b/registry/number/random/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Generates a random number between min and max (inclusive of min, exclusive of max).
+ *
+ * Provides a more convenient interface for generating random numbers within
+ * a specific range compared to Math.random(). Supports both integer and
+ * floating-point ranges.
+ *
+ * @param min The minimum value (inclusive)
+ * @param max The maximum value (exclusive)
+ * @param integer Whether to return an integer (default: false)
+ * @returns A random number within the specified range
+ *
+ * @example
+ * ```typescript
+ * // Random float between 0 and 1
+ * random(0, 1); // e.g., 0.7234
+ *
+ * // Random float between 5 and 10
+ * random(5, 10); // e.g., 7.832
+ *
+ * // Random integer between 1 and 6 (dice roll)
+ * random(1, 7, true); // e.g., 4
+ *
+ * // Random integer between 0 and 100
+ * random(0, 101, true); // e.g., 42
+ *
+ * // Random negative number
+ * random(-10, 10); // e.g., -3.456
+ * ```
+ */
+export function random(min: number, max: number, integer = false): number {
+  if (min > max) {
+    throw new Error('Minimum value cannot be greater than maximum value');
+  }
+
+  if (min === max) {
+    return min;
+  }
+
+  const randomValue = Math.random() * (max - min) + min;
+
+  return integer ? Math.floor(randomValue) : randomValue;
+}

--- a/registry/number/round/index.test.ts
+++ b/registry/number/round/index.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { round } from './index.js';
+
+describe('round', () => {
+  it('should round to nearest integer by default', () => {
+    expect(round(3.14159)).toBe(3);
+    expect(round(3.6)).toBe(4);
+    expect(round(2.5)).toBe(3);
+    expect(round(1.4)).toBe(1);
+  });
+
+  it('should round to specified decimal places', () => {
+    expect(round(3.14159, 2)).toBe(3.14);
+    expect(round(3.14159, 4)).toBe(3.1416);
+    expect(round(123.456, 1)).toBe(123.5);
+    expect(round(123.456, 3)).toBe(123.456);
+  });
+
+  it('should handle negative precision (round to tens, hundreds, etc.)', () => {
+    expect(round(123.456, -1)).toBe(120);
+    expect(round(123.456, -2)).toBe(100);
+    expect(round(1234.56, -3)).toBe(1000);
+    expect(round(156, -1)).toBe(160);
+    expect(round(150, -2)).toBe(200);
+  });
+
+  it('should handle negative numbers', () => {
+    expect(round(-3.14159)).toBe(-3);
+    expect(round(-3.6)).toBe(-4);
+    expect(round(-2.5)).toBe(-2); // JavaScript's Math.round behavior
+    expect(round(-123.456, 2)).toBe(-123.46);
+    expect(round(-156, -1)).toBe(-160);
+  });
+
+  it('should handle zero precision explicitly', () => {
+    expect(round(3.7, 0)).toBe(4);
+    expect(round(3.2, 0)).toBe(3);
+    expect(round(-3.7, 0)).toBe(-4);
+  });
+
+  it('should handle edge cases with precision', () => {
+    expect(round(1.005, 2)).toBe(1); // Due to floating-point precision, 1.005 is actually slightly less
+    expect(round(1.004, 2)).toBe(1);
+    expect(round(1.006, 2)).toBe(1.01); // This should round up clearly
+    expect(round(0.1 + 0.2, 2)).toBe(0.3); // Handle floating-point precision issues
+  });
+
+  it('should handle special number values', () => {
+    expect(round(Infinity)).toBe(Infinity);
+    expect(round(-Infinity)).toBe(-Infinity);
+    expect(round(NaN)).toBe(NaN);
+    expect(round(Infinity, 2)).toBe(Infinity);
+    expect(round(NaN, 2)).toBe(NaN);
+  });
+
+  it('should handle very large precision values', () => {
+    expect(round(3.14159, 10)).toBe(3.14159);
+    expect(round(3.14159, 20)).toBe(3.14159);
+  });
+
+  it('should handle zero values', () => {
+    expect(round(0)).toBe(0);
+    expect(round(0, 2)).toBe(0);
+    expect(round(-0)).toBe(-0);
+  });
+
+  it('should handle very small numbers', () => {
+    expect(round(0.0001, 3)).toBe(0);
+    expect(round(0.0001, 4)).toBe(0.0001);
+    expect(round(0.00015, 4)).toBe(0.0001); // Due to floating-point precision
+    expect(round(0.0002, 4)).toBe(0.0002); // This should be exact
+  });
+
+  it('should handle very large numbers', () => {
+    expect(round(999999.999, 2)).toBe(1000000);
+    expect(round(999999.994, 2)).toBe(999999.99);
+    expect(round(1e15, 2)).toBe(1e15);
+  });
+});

--- a/registry/number/round/index.ts
+++ b/registry/number/round/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Rounds a number to a specified number of decimal places.
+ *
+ * Provides more control over rounding than the built-in Math.round(),
+ * allowing you to specify the number of decimal places to round to.
+ * Uses standard mathematical rounding (round half up).
+ *
+ * @param value The number to round
+ * @param precision The number of decimal places (default: 0)
+ * @returns The rounded number
+ *
+ * @example
+ * ```typescript
+ * round(3.14159); // 3
+ * round(3.14159, 2); // 3.14
+ * round(3.14159, 4); // 3.1416
+ * round(123.456, 1); // 123.5
+ * round(123.456, -1); // 120 (round to nearest 10)
+ * round(123.456, -2); // 100 (round to nearest 100)
+ * round(2.5); // 3
+ * round(-2.5); // -2
+ * ```
+ */
+export function round(value: number, precision = 0): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+
+  const factor = Math.pow(10, precision);
+  return Math.round(value * factor) / factor;
+}


### PR DESCRIPTION
- Add clamp utility for constraining numbers between min/max bounds
- Add random utility for generating random numbers with integer option
- Add round utility for rounding to specified decimal places
- Add format-number utility with locale-aware formatting options
- Handle edge cases like special number values, negative precision
- Comprehensive test coverage with 44 test cases across all utilities
- Updated README.md with documentation and examples
- All utilities handle floating-point precision issues appropriately